### PR TITLE
update urls.py to use callables

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Anna Ossowski <https://github.com/ossanna16>
 Brian Rosner <brosner@gmail.com>
 Patrick Altman <https://github.com/paltman>
 Thomas Schreiber <https://github.com/rizumu>
+Trevor Watson <https://github.com/cfc603>

--- a/pinax/waitinglist/urls.py
+++ b/pinax/waitinglist/urls.py
@@ -1,12 +1,13 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.generic import TemplateView
 
+from . import views
 
-urlpatterns = patterns(
-    "pinax.waitinglist.views",
-    url(r"^list_signup/$", "list_signup", name="waitinglist_list_signup"),
-    url(r"^ajax_list_signup/$", "ajax_list_signup", name="waitinglist_ajax_list_signup"),
+
+urlpatterns = [
+    url(r"^list_signup/$", views.list_signup, name="waitinglist_list_signup"),
+    url(r"^ajax_list_signup/$", views.ajax_list_signup, name="waitinglist_ajax_list_signup"),
     url(r"^survey/thanks/$", TemplateView.as_view(template_name="waitinglist/thanks.html"), name="waitinglist_thanks"),
-    url(r"^survey/(?P<code>.*)/$", "survey", name="waitinglist_survey"),
+    url(r"^survey/(?P<code>.*)/$", views.survey, name="waitinglist_survey"),
     url(r"^success/$", TemplateView.as_view(template_name="waitinglist/success.html"), name="waitinglist_success"),
-)
+]


### PR DESCRIPTION
Fix for deprecation warning: RemovedInDjango110Warning

Fixes #2
