### PR TITLE
fix str issue in models across Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
 env:
+  - DJANGO=1.8
   - DJANGO=1.9
   - DJANGO=1.10
   - DJANGO=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO=1.8
+  - DJANGO=1.9
   - DJANGO=1.10
   - DJANGO=master
 install:

--- a/pinax/waitinglist/models.py
+++ b/pinax/waitinglist/models.py
@@ -6,12 +6,13 @@ from django.db import models
 from django.db.models import Max
 from django.template.defaultfilters import slugify
 from django.utils import timezone
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
-
 
 SURVEY_SECRET = getattr(settings, "WAITINGLIST_SURVEY_SECRET", settings.SECRET_KEY)
 
 
+@python_2_unicode_compatible
 class WaitingListEntry(models.Model):
 
     email = models.EmailField(_("email address"), unique=True)
@@ -23,16 +24,17 @@ class WaitingListEntry(models.Model):
         verbose_name = _("waiting list entry")
         verbose_name_plural = _("waiting list entries")
 
-    def __unicode__(self):
+    def __str__(self):
         return self.email
 
 
+@python_2_unicode_compatible
 class Survey(models.Model):
 
     label = models.CharField(max_length=100, unique=True)
     active = models.BooleanField(default=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.label
 
     def save(self, *args, **kwargs):
@@ -119,11 +121,12 @@ class SurveyQuestion(models.Model):
         return super(SurveyQuestion, self).save(*args, **kwargs)
 
 
+@python_2_unicode_compatible
 class SurveyQuestionChoice(models.Model):
     question = models.ForeignKey(SurveyQuestion, related_name="choices")
     label = models.CharField(max_length=100)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.label
 
 

--- a/pinax/waitinglist/tests/tests.py
+++ b/pinax/waitinglist/tests/tests.py
@@ -84,6 +84,9 @@ class SurveyFormTests(SurveyTestCase):
         form = SurveyForm(survey=self.survey)
         self.assertTrue(len(form.fields), 5)
 
+    def test_survey_strings(self):
+        self.assertEqual(str(self.summer), "Summer")
+
     def test_survey_form_invalid(self):
         form = SurveyForm(
             data={

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,15 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.8,1.10,master},
-    py34-{1.8,1.10,master},
-    py35-{1.8,1.10,master}
+    py27-{1.9,1.10,master},
+    py34-{1.9,1.10,master},
+    py35-{1.9,1.10,master}
 
 [testenv]
 deps =
     coverage == 4.0.2
     flake8 == 2.5.0
-    1.8: Django>=1.8,<1.9
+    1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
     master: https://github.com/django/django/tarball/master
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -6,14 +6,15 @@ exclude = migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.9,1.10,master},
-    py34-{1.9,1.10,master},
-    py35-{1.9,1.10,master}
+    py27-{1.8,1,9,1.10,master},
+    py34-{1.8,1.9,1.10,master},
+    py35-{1.8,1.9,1.10,master}
 
 [testenv]
 deps =
     coverage == 4.0.2
     flake8 == 2.5.0
+    1.8: Django>=1.8,<1.9
     1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
     master: https://github.com/django/django/tarball/master


### PR DESCRIPTION
* adds test exhibiting problem identified in #17 
* updates mistakes in test matrix
* switches to `__str__` with `@python_2_unicode_compatible` in models